### PR TITLE
Fixed issue with temp files crashing precompiler

### DIFF
--- a/handlebars-precompiler.js
+++ b/handlebars-precompiler.js
@@ -134,7 +134,7 @@ exports.watchDir = function(dir, outfile, extensions) {
       for(var i = 0; i < files.length; i++) {
         var file = files[i];
         if(regex.test(file)) {
-          fs.watch(file, compileOnChange);
+          fs.watchFile(file, { interval: 207, persistent: true }, compileOnChange);
         }
       }
     }


### PR DESCRIPTION
Added a simple check to block temp files from accidentally being sent into processTemplate(), which crashes the process.
