### PR TITLE
Compile on startup, not just when files change

### DIFF
--- a/handlebars-precompiler.js
+++ b/handlebars-precompiler.js
@@ -130,6 +130,14 @@ exports.watchDir = function(dir, outfile, extensions) {
       min: true
     });
   }
+  
+  // compile immediately
+  exports.do({
+    templates: [dir],
+    output: outfile,
+    fileRegex: regex,
+    min: true
+  });
 
   file.walk(dir, function(_, dirPath, dirs, files) {
     if(files) {


### PR DESCRIPTION
If a file is modified before the app starts up, the contents in the compiled file will be out of date because files are not compiled on startup.

This change simply compiles on startup before doing the file watch.
