### PR TITLE
Use fs.watchFile instead of fs.watch for compatibility

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -85,6 +85,8 @@ Compiles all of the Handlebars templates in the specified directory and monitors
 
     * `opts.extensions` An array of extensions of files (eg `['hbs']`) to compile as Handlebars templates (takes precedence over fileRegex) (`string[]`)
 
+    * `opts.pollInterval` Interval in milliseconds at which files are polled for changes (default: 500) (`number`)
+ 
     * `opts.fileRegex` A regular expression of the files to compile as Handlebars templates (instead of using .extensions) (`RegExp`)
 
     * `opts.min` Whether or not to minify the files (default: true) (`boolean`)
@@ -104,6 +106,7 @@ Compiles all of the Handlebars templates in the specified directory and monitors
 * Project created by Joel Wietelmann
 * Nic Jansma
 * Matt Null
+* Brandon Paton
 
 ## Version History
 

--- a/handlebars-precompiler.js
+++ b/handlebars-precompiler.js
@@ -158,6 +158,7 @@ exports.watchDir = function(dir, outfile, extensions) {
  * @param {string}   outfile            Output file name
  * @param {object}   opts               Options
  * @param {string[]} opts.extensions    An array of extensions (eg 'hbs') of files to compile as Handlebars templates (takes precedence over fileRegex)
+ * @param {number}   opts.pollInterval  Interval in milliseconds at which files are polled for changes (default: 500)
  * @param {RegExp}   opts.fileRegex     A regular expression of the files to compile as Handlebars templates (instead of using .extensions)
  * @param {boolean}  opts.min           Whether or not to minify the files (default: true)
  * @param {boolean}  opts.silent        Silence console output (default: false)
@@ -170,6 +171,7 @@ exports.watch = function(dir, outfile, opts) {
   // defaults to send to .do()
   var defaults = {
     extensions: null,
+    pollInterval: 500,
     fileRegex: /\.handlebars$/,
     min: true,
     silent: false,
@@ -218,7 +220,7 @@ exports.watch = function(dir, outfile, opts) {
         var file = files[i];
         if (options.fileRegex.test(file)) {
           // watch this file for changes
-          fs.watch(file, compileOnChange);
+          fs.watchFile(file, { interval: options.pollInterval, persistent: true }, compileOnChange);
 
           if (!options.silent) {
             console.log('[watching] ' + file);


### PR DESCRIPTION
Some text editors (like vim) write to a temp file, and the overwrite the original file with the temp file. 

fs.watch works by listening to a particular file, so when I save a file, the original watcher is disconnected (because the file was overwritten by temp file) and the file is no longer being watched.

Switching to fs.watchFile fixes this problem because fs.watchFile works by polling the file to check for changes, while fs.watch uses a lower level file-watching feature of the operating system it's running on.

I've been using a [version of this module with this change](https://github.com/paton/node-handlebars-precompiler) for the last year and it's worked well.
