### PR TITLE
Upgrade to Handlebars v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=0.4.7"
   },
   "dependencies": {
-    "handlebars": "~1.0",
+    "handlebars": "^2.0.0",
     "uglify-js": "~1.2",
     "watch": "^0.11.0",
     "lodash": ">= 0.0.0"


### PR DESCRIPTION
This fixes #12 

@nicjansma We should probably bump this library to 1.1.0 or 2.0.0 since Handlebars 2 isn't backwards compatible with the v1 handlebars.runtime.js
